### PR TITLE
Disable Lean-specific header by default.

### DIFF
--- a/archive.py
+++ b/archive.py
@@ -45,6 +45,9 @@ def get_config(section: str, key: str, default_value: Optional[Any]=None) -> Opt
 zulip_url = get_config("api", "site")
 # The user-facing root url. Only needed for md/html generation.
 site_url = get_config("archive", "root_url", "file://" + os.path.abspath(os.path.dirname(__file__)))
+# Flag to determine whether the archive is a Lean archive or not,
+# used in determining the header.
+is_lean_archive = False
 
 # Streams in stream_blacklist are ignored.
 # If stream_whitelist is nonempty, only streams that appear there and not in
@@ -91,9 +94,12 @@ last_updated_file = Path("archive_update.html") # filename for update timestamp
 
 # writes the Jekyll header info for the index page listing all streams.
 def write_stream_index_header(outfile):
-    outfile.writelines(['---\n', 'layout: archive\n', 'title: Lean Prover Zulip Chat Archive\n'])
-    outfile.write('permalink: {}/index.html\n'.format(html_root))
-    outfile.writelines(['---\n\n','---\n\n','## Streams:\n\n'])
+    if is_lean_archive:
+        outfile.writelines(['---\n', 'layout: archive\n', 'title: Lean Prover Zulip Chat Archive\n'])
+        outfile.write('permalink: {}/index.html\n'.format(html_root))
+        outfile.writelines(['---\n\n', '---\n\n', '## Streams:\n\n'])
+    else:
+        outfile.write('# Streams:\n\n\n')
 
 # writes the index page listing all streams.
 # `streams`: a dict mapping stream names to stream json objects as described in the header.

--- a/archive.py
+++ b/archive.py
@@ -22,12 +22,12 @@
 # This json file is a list of message objects, as desribed at https://zulipchat.com/api/get-messages
 #
 
-from datetime import date, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
 from zlib import adler32
 import configparser
-import zulip, string, os, time, json, urllib, argparse, subprocess
+import zulip, os, time, json, urllib, argparse, subprocess
 
 ## Configuration options
 # config_file should point to a Zulip api config


### PR DESCRIPTION
This resolves the incompatibility caused by https://github.com/zulip/zulip_archive/commit/fd144215b4afc03881e28f72c6258ee92ecd0228.
The hardcoded Lean-specific header should be disabled by default, so that the script becomes generic and can be used by other project.

This is the solution I chose, since the other alternative, i.e. specifying the header in a zuliprc may have newlines formatting problem (it can't handle `\n\n`) or that if the header is too long.