### PR TITLE
Put styles in stylesheet.

### DIFF
--- a/archive.py
+++ b/archive.py
@@ -24,6 +24,7 @@
 
 from datetime import datetime
 from pathlib import Path
+from shutil import copyfile
 from typing import Any, Optional
 from zlib import adler32
 import configparser
@@ -145,6 +146,7 @@ def write_topic_index(stream_name, stream):
 
 # formats the header for a topic page.
 def write_topic_header(outfile, stream_name, stream_id, topic_name):
+    outfile.write('<head><link href="/style.css" rel="stylesheet"></head>')
     permalink = 'permalink: {0}/{1}/{2}.html'.format(
         html_root,
         sanitize_stream(stream_name, stream_id),
@@ -376,6 +378,9 @@ def write_last_updated(t):
     f.write('<hr><p>Last updated: {} UTC</p>'.format(t))
     f.close()
 
+def write_css():
+    copyfile('style.css', md_root / 'style.css')
+
 # writes all markdown files to md_root, based on the archive at json_root.
 def write_markdown():
     f = (json_root / Path('stream_index.json')).open('r', encoding='utf-8')
@@ -384,6 +389,7 @@ def write_markdown():
     streams = stream_info['streams']
     write_last_updated(str(stream_info['time']))
     write_stream_index(streams)
+    write_css()
     for s in streams:
         print('building: ', s)
         write_topic_index(s, streams[s])

--- a/style.css
+++ b/style.css
@@ -1,0 +1,1 @@
+.msg { margin-left: 2em; }


### PR DESCRIPTION
Based on:
https://github.com/zulip/zulip_archive/commit/1373f6c5591ae39c1aba8d998cea452e8b865398

The original style line at https://github.com/zulip/zulip_archive/commit/1373f6c5591ae39c1aba8d998cea452e8b865398#diff-9f4c120f069c8b5413c170953b0b8ab8L153 is gone in current master. So this commit actually adds a `<style>` instead of changing its location.