### PR TITLE
update xml_sitemap_writer to 0.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyyaml==5.2
-xml-sitemap-writer==0.5.0
+xml-sitemap-writer==0.6.0
 zulip==0.8.2


### PR DESCRIPTION
0.5.0 is incompatible with python 3.12 and more recent, with the following error observed in CI:

```
Traceback (most recent call last):
  File "/builds/gasche/types-chat-archive/zulip-archive/archive.py", line 52, in <module>
    from lib.sitemap import build_sitemap
  File "/builds/gasche/types-chat-archive/zulip-archive/lib/sitemap.py", line 4, in <module>
    from xml_sitemap_writer import XMLSitemap
  File "/root/.local/lib/python3.13/site-packages/xml_sitemap_writer.py", line 8, in <module>
    from typing.io import IO  # pylint:disable=import-error
```

(The incompatibility is due to the removal of 'typing.io' in 3.12, see [here](https://github.com/Almenon/AREPL-vscode/issues/416#issuecomment-1277965222) for some discussion.)

I have checked manually that the zulip-archive works fine with xml_sitemap_writer 0.6.0, which supports python 3.12 and 3.13.